### PR TITLE
osm support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ It makes use of the [addProtocol](https://github.com/maplibre/maplibre-gl-js/pul
 
 It can be used with MapboxGLJS 1.x.x using the [mapbox-gl-custom-protocol](https://www.github.com/jimmyrocks/mapbox-gl-custom-protocol) library. I haven't tested it with MapboxGLJS 2+.
 
-Web workers are used to convert `CSV`, `TSV`, and `Topojson` formats. `KML`, `GPX`, and `TCX` formats are based on XML and use the [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser), which isn't available to web workers, so they are converted to GeoJSON in the main thread.
+Web workers are used to convert `CSV`, `TSV`, `Topojson`, and `OSM` formats. `KML`, `GPX`, and `TCX` formats are based on XML and use the [DOMParser](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser), which isn't available to web workers, so they are converted to GeoJSON in the main thread.
 
 ## Supported Formats 🗎
 * [`Topojson`](https://en.wikipedia.org/wiki/GeoJSON#TopoJSON) - A more compact JSON based format than [GeoJSON](https://en.wikipedia.org/wiki/GeoJSON) that takes advantage of shared **topo**logies.
+* [`OSM`](https://wiki.openstreetmap.org/wiki/OSM_JSON) - Open Street Map json/xml.
 * [`KML`](https://en.wikipedia.org/wiki/Keyhole_Markup_Language) - **K**eyhole **M**arkup **L**anguage, popularized by [Google Earth](https://en.wikipedia.org/wiki/Google_Earth).
 * [`GPX`](https://en.wikipedia.org/wiki/GPS_Exchange_Format) - **GP**S E**x**change Format - A common XML-based format used by may GPS devices.
 * [`TCX`](https://en.wikipedia.org/wiki/Training_Center_XML) - **T**raining **C**enter **X**ML - An XML-based format used by various Garmin devices and applications (e.g. [Garmin Connect](https://connect.garmin.com)).
@@ -21,13 +22,14 @@ The [`addProtocol`](https://github.com/maplibre/maplibre-gl-js/blob/492bec58c568
 ## Inspiration 💡
 I have worked on many projects where users want to add their own data to a map, but their data is rarely in the right format. This library makes it as easy as adding a `csv://` before the file path to bring a csv file in.
 
-There are a lot of [Geospatial File Formats](https://en.wikipedia.org/wiki/GIS_file_formats#Vector) out there, this library is intended to serve the most common formats (CSV, KML, GPX, Topojson) without creating a huge library. There are other formats I would like to support, but they will be available in different libraries.
+There are a lot of [Geospatial File Formats](https://en.wikipedia.org/wiki/GIS_file_formats#Vector) out there, this library is intended to serve the most common formats (CSV, KML, GPX, Topojson, OSM) without creating a huge library. There are other formats I would like to support, but they will be available in different libraries.
 
 ## External Libraries 📚
 This project would not be possible if it weren't for three core libraries that drive it:
 * `@tmcw/togeojson` - Supported by [placemark.io](https:placemark.io) - `KML`, `GPX`, `TCX` support
 * `csv2geojson` - Supported by [Mapbox](https://mapbox.com) - `CSV`, `TSV` support
 * `topojson-client` - From [Mike Bostock](https://github.com/mbostock) - `Topojson` support
+* `osm2geojson-lite` - From [tibetty](https://github.com/tibetty/osm2geojson-lite) - `osm2geojson-lite` support
 
 I'd also like to thank the Mapbox🚀 and Maplibre teams for creating such a great project that is easily extendable.
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -59,6 +59,45 @@ map.on('load', () => {
         }
     });
 
+    // OSM polygon (json)
+    const osmSourceName = 'marsh (osm polygon json)';
+    const osmLink = 'osm://https://www.openstreetmap.org/api/0.6/relation/5544086/full.json'
+    map.addSource(osmSourceName, {
+        'type': 'geojson',
+        'data': osmLink,
+    });
+    map.addLayer({
+        'id': layerIdPrefix + osmSourceName,
+        'type': 'fill',
+        'source': osmSourceName,
+        'minzoom': 0,
+        'maxzoom': 20,
+        'paint': {
+            'fill-opacity': 0.25,
+            'fill-color': 'blue',
+            'fill-outline-color': 'gray'
+        }
+    });
+
+    // OSM line (xml)
+    const osmLineSourceName = 'madison ave (osm line xml)';
+    const osmLineLink = 'osm://https://www.openstreetmap.org/api/0.6/relation/968291/full'
+    map.addSource(osmLineSourceName, {
+        'type': 'geojson',
+        'data': osmLineLink,
+    });
+    map.addLayer({
+        'id': layerIdPrefix + osmLineSourceName,
+        'type': 'line',
+        'source': osmLineSourceName,
+        'minzoom': 0,
+        'maxzoom': 20,
+        'paint': {
+            'line-opacity': 0.4,
+            'line-color': 'blue',
+        }
+    });
+
     // CSV
     const csvSourceName = 'restaurants (csv)';
     const csvLink = 'csv://./data/cape_may_restaurants.csv';

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "keywords": [
         "maplibre",
         "topojson",
+        "osm",
         "kml",
         "gpx",
         "tcx",
@@ -31,6 +32,7 @@
     "devDependencies": {
         "@open-wc/building-rollup": "^2.2.3",
         "@rollup/plugin-commonjs": "^24.0.1",
+        "@rollup/plugin-json": "^6.0.0",
         "@rollup/plugin-node-resolve": "^15.0.2",
         "@types/geojson": "^7946.0.10",
         "@types/jest": "^29.5.0",
@@ -47,6 +49,7 @@
     "dependencies": {
         "@tmcw/togeojson": "5.6.0",
         "csv2geojson": "^5.1.2",
-        "topojson-client": "^3.1.0"
+        "topojson-client": "^3.1.0",
+        "osm2geojson-lite": "^0.9.2"
     }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,7 @@ import { terser } from "rollup-plugin-terser";
 import { default as typescript } from 'rollup-plugin-typescript2';
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
+import json from '@rollup/plugin-json';
 import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 
 import fs from 'fs';
@@ -20,7 +21,7 @@ const baseConfig = {
   treeshake: env === 'production',
   plugins: [webWorkerLoader({
     'extensions': ['.ts']
-  }), typescript(), nodeResolve(), commonjs()]
+  }), typescript(), nodeResolve(), commonjs(), json()]
 };
 
 const configs = [{

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -3,8 +3,9 @@ import { Topology } from 'topojson-specification'
 import * as csv2geojson from 'csv2geojson';
 import { feature as topojsonFeature } from 'topojson-client';
 import * as toGeoJson from '@tmcw/togeojson';
+import osm2geojson from 'osm2geojson-lite';
 
-export const supportedFormats = ['topojson', 'kml', 'gpx', 'tcx', 'csv', 'tsv'] as const;
+export const supportedFormats = ['topojson', 'osm', 'kml', 'gpx', 'tcx', 'csv', 'tsv'] as const;
 export type supportedFormatsType = typeof supportedFormats[number];
 
 
@@ -19,6 +20,7 @@ export class Converter {
 
         const converters: { [key: string]: () => Promise<FeatureCollection> } = {
             'topojson': this.loadTopoJson,
+            'osm': this.loadOsm,
             'kml': this.loadXml,
             'gpx': this.loadXml,
             'tcx': this.loadXml,
@@ -119,4 +121,7 @@ export class Converter {
         }
         return result;
     };
+    async loadOsm(): Promise<FeatureCollection> {
+        return osm2geojson(this._rawData) as FeatureCollection;
+    }
 }


### PR DESCRIPTION
So, I know you said this:

> There are other formats I would like to support, but they will be available in different libraries.

But, I feel like OSM is a good candidate for being in your main protocol project.  If you disagree, though, can you coach me on a good way to use your infrastructure but put this into a separate library?

If you want to see this in-use, I added to the examples directory.